### PR TITLE
Add QMessageHandler context manager

### DIFF
--- a/superqt/__init__.py
+++ b/superqt/__init__.py
@@ -17,6 +17,7 @@ from .sliders import (
     QRangeSlider,
 )
 from .spinbox import QLargeIntSpinBox
+from .utils import QMessageHandler
 
 __all__ = [
     "QDoubleRangeSlider",
@@ -27,6 +28,7 @@ __all__ = [
     "QLabeledRangeSlider",
     "QLabeledSlider",
     "QLargeIntSpinBox",
+    "QMessageHandler",
     "QRangeSlider",
     "QEnumComboBox",
 ]

--- a/superqt/utils/__init__.py
+++ b/superqt/utils/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["QMessageHandler"]
+
+from ._message_handler import QMessageHandler

--- a/superqt/utils/_message_handler.py
+++ b/superqt/utils/_message_handler.py
@@ -1,0 +1,98 @@
+import logging
+from contextlib import suppress
+from typing import List, NamedTuple, Optional
+
+from superqt.qtcompat.QtCore import (
+    QMessageLogContext,
+    QtMsgType,
+    qInstallMessageHandler,
+)
+
+
+class Record(NamedTuple):
+    level: int
+    message: str
+    ctx: dict
+
+
+class QMessageHandler:
+    """A context manager to intercept messages from Qt.
+
+    Parameters
+    ----------
+    logger : logging.Logger, optional
+        If provided, intercepted messages will be logged with `logger` at the
+        corresponding python log level, by default None
+
+    Attributes
+    ----------
+    records: list of tuple
+        Captured messages. This is a 3-tuple of:
+        `(log_level: int, message: str, context: dict)`
+
+    Examples
+    --------
+
+    >>> handler = QMessageHandler()
+    >>> handler.install()  # now all Qt output will be available at mh.records
+
+    >>> with QMessageHandler() as handler:  # temporarily install
+    ...     ...
+
+    >>> logger = logging.getLogger(__name__)
+    >>> with QMessageHandler(logger):  # re-reoute Qt messages to a python logger.
+    ...    ...
+    """
+
+    _qt2loggertype = {
+        QtMsgType.QtDebugMsg: logging.DEBUG,
+        QtMsgType.QtInfoMsg: logging.INFO,
+        QtMsgType.QtWarningMsg: logging.WARNING,
+        QtMsgType.QtCriticalMsg: logging.ERROR,  # note
+        QtMsgType.QtFatalMsg: logging.CRITICAL,  # note
+        QtMsgType.QtSystemMsg: logging.CRITICAL,
+    }
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.records: List[Record] = []
+        self._logger = logger
+        self._previous_handler: Optional[object] = "__uninstalled__"
+
+    def install(self):
+        """Install this handler (override the current QtMessageHandler)."""
+        self._previous_handler = qInstallMessageHandler(self)
+
+    def uninstall(self):
+        """Uninstall this handler, restoring the previous handler."""
+        if self._previous_handler != "__uninstalled__":
+            qInstallMessageHandler(self._previous_handler)
+
+    def __repr__(self):
+        n = type(self).__name__
+        return f"<{n} object at {hex(id(self))} with {len(self.records)} records>"
+
+    def __enter__(self):
+        """Enter a context with this handler installed"""
+        self.install()
+        return self
+
+    def __exit__(self, *args):
+        self.uninstall()
+
+    def __call__(self, msgtype: QtMsgType, context: QMessageLogContext, message: str):
+        level = self._qt2loggertype[msgtype]
+
+        # PyQt seems to throw an error if these are simply empty
+        ctx = dict.fromkeys(["category", "file", "function", "line"])
+        with suppress(UnicodeDecodeError):
+            ctx["category"] = context.category
+        with suppress(UnicodeDecodeError):
+            ctx["file"] = context.file
+        with suppress(UnicodeDecodeError):
+            ctx["function"] = context.function
+        with suppress(UnicodeDecodeError):
+            ctx["line"] = context.line
+
+        self.records.append(Record(level, message, ctx))
+        if self._logger is not None:
+            self._logger.log(level, message, extra=ctx)

--- a/superqt/utils/_tests/test_qmessage_handler.py
+++ b/superqt/utils/_tests/test_qmessage_handler.py
@@ -1,0 +1,35 @@
+import logging
+
+from superqt import QMessageHandler
+from superqt.qtcompat import QtCore
+
+
+def test_message_handler():
+    with QMessageHandler() as mh:
+        QtCore.qDebug("debug")
+        QtCore.qWarning("warning")
+        QtCore.qCritical("critical")
+
+    assert len(mh.records) == 3
+    assert mh.records[0].level == logging.DEBUG
+    assert mh.records[1].level == logging.WARNING
+    assert mh.records[2].level == logging.CRITICAL
+
+    assert "3 records" in repr(mh)
+
+
+def test_message_handler_with_logger(caplog):
+    logger = logging.getLogger("test_logger")
+    caplog.set_level(logging.DEBUG, logger="test_logger")
+    with QMessageHandler(logger):
+        QtCore.qDebug("debug")
+        QtCore.qWarning("warning")
+        QtCore.qCritical("critical")
+
+    assert len(caplog.records) == 3
+    caplog.records[0].message == "debug"
+    caplog.records[0].levelno == logging.DEBUG
+    caplog.records[1].message == "warning"
+    caplog.records[1].levelno == logging.WARNING
+    caplog.records[2].message == "critical"
+    caplog.records[2].levelno == logging.CRITICAL


### PR DESCRIPTION
This adds a convenient way to intercept, store, and re-reroute Qt messages from stdout to a python logger:

```python
# Install a permanent message handler
handler = QMessageHandler()
handler.install()  

# temporarily install
with QMessageHandler() as handler:  
    ...

# re-reoute Qt messages to a python logger at the appropriate level
logger = logging.getLogger(__name__)
with QMessageHandler(logger):  
    ...
```