### PR TITLE
Add `ensure_main_tread` and `ensure_object_thread`

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,0 +1,89 @@
+# Decorators
+
+
+## Move to thread decorators
+
+`superqt` provides two decorators for ensure that given function is running in proper thread:
+
+* `ensure_main_thread` - run function/method in main thread
+* `ensure_object_thread` - run method of `QObject` instance in thread in which given instance live ([qt documentation](https://doc.qt.io/qt-5/threads-qobject.html#accessing-qobject-subclasses-from-other-threads)).
+
+By default, functions are executed in async mode:
+
+```python
+from PySide2.QtCore import QObject
+from superqt import ensure_main_thread, ensure_object_thread
+
+@ensure_main_thread
+def sample_function():
+    print("This function will run in main thread")
+
+
+class SampleObject(QObject):
+    def __init__(self):
+        super().__init__()
+        self._value = 1
+    @ensure_main_thread
+    def sample_method1(self):
+        print("This method will run in main thread")
+
+    @ensure_main_thread()
+    def sample_method2(self):
+        print("This method also will run in main thread")
+
+    @ensure_object_thread
+    def sample_method3(self):
+        print("This method will run in object thread")
+
+    @ensure_object_thread()
+    def sample_method4(self):
+        print("This method also will run in object thread")
+
+    @property
+    def value(self):
+        print("return value")
+        return self._value
+
+    @value.setter
+    @ensure_object_thread
+    def value(self, value):
+        print("this setter will run in object thread")
+        self._value = value
+```
+
+As visible on example these decorators also could be used for setters.
+
+These decorators should not be used as replacement of Qt Signals but rather to interact with Qt objects from non Qt code.
+
+### Sync mode
+
+Secorators could be used also in sync mode:
+
+```python
+
+from superqt import ensure_main_thread
+
+@ensure_main_thread
+def sample_function1():
+    return 1
+
+@ensure_main_thread(no_return=False)
+def sample_function2():
+    return 2
+
+assert sample_function1() is None
+assert sample_function2() == 2
+```
+
+Using sync mode may introduce significant performance impact.
+
+Decorators also provide `timeout` argument (in milliseconds). Works only with `no_return=False`
+
+```python
+
+from superqt import ensure_main_thread
+
+@ensure_main_thread(no_return=False, timeout=1000)
+def sample_function():
+    return 1
+```

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -67,7 +67,7 @@ from superqt import ensure_main_thread
 def sample_function1():
     return 1
 
-@ensure_main_thread(no_return=False)
+@ensure_main_thread(await_return=True)
 def sample_function2():
     return 2
 
@@ -77,13 +77,13 @@ assert sample_function2() == 2
 
 Using sync mode may introduce significant performance impact.
 
-Decorators also provide `timeout` argument (in milliseconds). Works only with `no_return=False`
+Decorators also provide `timeout` argument (in milliseconds). Works only with `await_return=True`
 
 ```python
 
 from superqt import ensure_main_thread
 
-@ensure_main_thread(no_return=False, timeout=1000)
+@ensure_main_thread(await_return=True, timeout=1000)
 def sample_function():
     return 1
 ```

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -10,7 +10,10 @@ running in the desired thread:
   thread in which the instance lives ([qt
   documentation](https://doc.qt.io/qt-5/threads-qobject.html#accessing-qobject-subclasses-from-other-threads)).
 
-By default, functions are executed asynchronously (they return immediately without a result of `None`: see also [Synchronous mode](#synchronous-mode)
+By default, functions are executed asynchronously (they return immediately with
+an instance of
+[`concurrent.futures.Future`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future)).
+To block and wait for the result, see [Synchronous mode](#synchronous-mode)
 
 ```python
 from superqt.qtcompat.QtCore import QObject
@@ -25,21 +28,17 @@ class SampleObject(QObject):
     def __init__(self):
         super().__init__()
         self._value = 1
+
     @ensure_main_thread
     def sample_method1(self):
         print("This method will run in main thread")
 
-    @ensure_main_thread()
-    def sample_method2(self):
-        print("This method also will run in main thread")
-
     @ensure_object_thread
     def sample_method3(self):
+        import time
+        print("sleeping")
+        time.sleep(1)
         print("This method will run in object thread")
-
-    @ensure_object_thread()
-    def sample_method4(self):
-        print("This method also will run in object thread")
 
     @property
     def value(self):
@@ -55,14 +54,15 @@ class SampleObject(QObject):
 
 As can be seen in this example these decorators can also be used for setters.
 
-These decorators should not be used as replacement of Qt Signals but rather to interact with Qt objects from non Qt code.
+These decorators should not be used as replacement of Qt Signals but rather to
+interact with Qt objects from non Qt code.
 
 ### Synchronous mode
 
-If you'd like for the program to block and wait for the result of your function call, use the `await_return=True` parameter, and optionally specify a timeout.
+If you'd like for the program to block and wait for the result of your function
+call, use the `await_return=True` parameter, and optionally specify a timeout.
 
 > *Note: Using synchronous mode may significantly impact performance.*
-
 
 ```python
 from superqt import ensure_main_thread

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,14 +1,16 @@
 # Decorators
 
-
 ## Move to thread decorators
 
-`superqt` provides two decorators for ensure that given function is running in proper thread:
+`superqt` provides two decorators that help to ensure that given function is
+running in the desired thread:
 
-* `ensure_main_thread` - run function/method in main thread
-* `ensure_object_thread` - run method of `QObject` instance in thread in which given instance live ([qt documentation](https://doc.qt.io/qt-5/threads-qobject.html#accessing-qobject-subclasses-from-other-threads)).
+* `ensure_main_thread` - ensures that the decorated function/method runs in the main thread
+* `ensure_object_thread` - ensures that a decorated bound method of a `QObject` runs in the
+  thread in which the instance lives ([qt
+  documentation](https://doc.qt.io/qt-5/threads-qobject.html#accessing-qobject-subclasses-from-other-threads)).
 
-By default, functions are executed in async mode:
+By default, functions are executed asynchronously (they return immediately without a result of `None`: see also [Synchronous mode](#synchronous-mode)
 
 ```python
 from superqt.qtcompat.QtCore import QObject
@@ -51,16 +53,18 @@ class SampleObject(QObject):
         self._value = value
 ```
 
-As visible on example these decorators also could be used for setters.
+As can be seen in this example these decorators can also be used for setters.
 
 These decorators should not be used as replacement of Qt Signals but rather to interact with Qt objects from non Qt code.
 
-### Sync mode
+### Synchronous mode
 
-Secorators could be used also in sync mode:
+If you'd like for the program to block and wait for the result of your function call, use the `await_return=True` parameter, and optionally specify a timeout.
+
+> *Note: Using synchronous mode may significantly impact performance.*
+
 
 ```python
-
 from superqt import ensure_main_thread
 
 @ensure_main_thread
@@ -73,17 +77,10 @@ def sample_function2():
 
 assert sample_function1() is None
 assert sample_function2() == 2
-```
 
-Using sync mode may introduce significant performance impact.
-
-Decorators also provide `timeout` argument (in milliseconds). Works only with `await_return=True`
-
-```python
-
-from superqt import ensure_main_thread
-
-@ensure_main_thread(await_return=True, timeout=1000)
+# optionally, specify a timeout
+@ensure_main_thread(await_return=True, timeout=10000)
 def sample_function():
     return 1
+
 ```

--- a/superqt/__init__.py
+++ b/superqt/__init__.py
@@ -17,9 +17,11 @@ from .sliders import (
     QRangeSlider,
 )
 from .spinbox import QLargeIntSpinBox
-from .utils import QMessageHandler
+from .utils import QMessageHandler, ensure_main_thread, ensure_object_thread
 
 __all__ = [
+    "ensure_main_thread",
+    "ensure_object_thread",
     "QDoubleRangeSlider",
     "QDoubleSlider",
     "QElidingLabel",

--- a/superqt/utils/__init__.py
+++ b/superqt/utils/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["QMessageHandler"]
+__all__ = ("QMessageHandler", "ensure_object_thread", "ensure_main_thread")
 
+from ._ensure_thread import ensure_main_thread, ensure_object_thread
 from ._message_handler import QMessageHandler

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -32,7 +32,15 @@ class CallCallable(QObject):
         self.finished.emit(res)
 
 
-def ensure_main_thread(no_return=True, timeout=1000):
+def ensure_main_thread(no_return: bool = True, timeout: int = 1000):
+    """
+    This is decorator which move function call to main thread (Thread in which QApplication was created).
+    It could be applied to functions and methods.
+
+    :param bool no_return: if wait on result of function result, default True
+    :param int timeout: timeout for waiting on result
+    """
+
     def _out_func(func):
         def _func(*args, **kwargs):
             return _run_in_thread(
@@ -49,7 +57,15 @@ def ensure_main_thread(no_return=True, timeout=1000):
     return _out_func
 
 
-def ensure_object_thread(no_return=True, timeout=1000):
+def ensure_object_thread(no_return: bool = True, timeout: int = 1000):
+    """
+    This is decorator which move function call to object thread.
+    It could be applied to methods of QObject instances.
+
+    :param bool no_return: if wait on result of function result, default True
+    :param int timeout: timeout for waiting on result
+    """
+
     def _out_func(func):
         def _func(self, *args, **kwargs):
             return _run_in_thread(

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -81,6 +81,9 @@ def _run_in_thread(
     func: Callable, thread: QThread, no_return: bool, timeout: int, *args, **kwargs
 ):
     if thread is QThread.currentThread():
+        if no_return:
+            func(*args, **kwargs)
+            return
         return func(*args, **kwargs)
     f = CallCallable(func, *args, **kwargs)
     f.moveToThread(thread)

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -1,4 +1,5 @@
 # https://gist.github.com/FlorianRhiem/41a1ad9b694c14fb9ac3
+from typing import Callable
 
 from superqt.qtcompat.QtCore import (
     QCoreApplication,
@@ -24,39 +25,67 @@ class CallCallable(QObject):
         self._kwargs = kwargs
         CallCallable.instances.append(self)
 
-    @Slot
+    @Slot()
     def call(self):
         CallCallable.instances.remove(self)
         res = self._callable(*self._args, **self._kwargs)
         self.finished.emit(res)
 
 
-def ensure_main_thread(func, no_return=True, timeout=1000):
-    def _func(*args, **kwargs):
-        if QCoreApplication.instance().thread() == QThread.currentThread():
-            return func(*args, **kwargs)
-        f = CallCallable(func, *args, **kwargs)
-        f.moveToThread(QCoreApplication.instance().thread())
-        if no_return:
-            QMetaObject.invokeMethod(f, "call", Qt.QueuedConnection)
-            return
+def ensure_main_thread(no_return=True, timeout=1000):
+    def _out_func(func):
+        def _func(*args, **kwargs):
+            return _run_in_thread(
+                func,
+                QCoreApplication.instance().thread(),
+                no_return,
+                timeout,
+                *args,
+                **kwargs
+            )
 
-        res = []
+        return _func
 
-        def set_res(data):
-            res.append(data)
+    return _out_func
 
-        f.finished.connect(set_res)
-        timer = QTimer()
-        timer.setSingleShot(True)
-        loop = QEventLoop()
-        f.finished.connect(loop.quit)
-        timer.timeout.connect(loop.quit)
-        timer.start(timeout)
+
+def ensure_object_thread(no_return=True, timeout=1000):
+    def _out_func(func):
+        def _func(self, *args, **kwargs):
+            return _run_in_thread(
+                func, self.thread(), no_return, timeout, self, *args, **kwargs
+            )
+
+        return _func
+
+    return _out_func
+
+
+def _run_in_thread(
+    func: Callable, thread: QThread, no_return: bool, timeout: int, *args, **kwargs
+):
+    if thread is QThread.currentThread():
+        return func(*args, **kwargs)
+    f = CallCallable(func, *args, **kwargs)
+    f.moveToThread(thread)
+    if no_return:
         QMetaObject.invokeMethod(f, "call", Qt.QueuedConnection)
-        loop.exec_()
-        if len(res) == 0:
-            raise TimeoutError("Not recived value")
-        return res[0]
+        return
 
-    return _func
+    res = []
+
+    def set_res(data):
+        res.append(data)
+
+    f.finished.connect(set_res)
+    timer = QTimer()
+    timer.setSingleShot(True)
+    loop = QEventLoop()
+    f.finished.connect(loop.quit)
+    timer.timeout.connect(loop.quit)
+    timer.start(timeout)
+    QMetaObject.invokeMethod(f, "call", Qt.QueuedConnection)
+    loop.exec_()
+    if len(res) == 0:
+        raise TimeoutError("Not recived value")
+    return res[0]

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -1,5 +1,5 @@
 # https://gist.github.com/FlorianRhiem/41a1ad9b694c14fb9ac3
-from typing import Callable
+from typing import Callable, Optional
 
 from superqt.qtcompat.QtCore import (
     QCoreApplication,
@@ -32,7 +32,9 @@ class CallCallable(QObject):
         self.finished.emit(res)
 
 
-def ensure_main_thread(no_return: bool = True, timeout: int = 1000):
+def ensure_main_thread(
+    func: Optional[Callable] = None, no_return: bool = True, timeout: int = 1000
+):
     """
     This is decorator which move function call to main thread (Thread in which QApplication was created).
     It could be applied to functions and methods.
@@ -54,10 +56,14 @@ def ensure_main_thread(no_return: bool = True, timeout: int = 1000):
 
         return _func
 
-    return _out_func
+    if func is None:
+        return _out_func
+    return _out_func(func)
 
 
-def ensure_object_thread(no_return: bool = True, timeout: int = 1000):
+def ensure_object_thread(
+    func: Optional[Callable] = None, no_return: bool = True, timeout: int = 1000
+):
     """
     This is decorator which move function call to object thread.
     It could be applied to methods of QObject instances.
@@ -74,7 +80,9 @@ def ensure_object_thread(no_return: bool = True, timeout: int = 1000):
 
         return _func
 
-    return _out_func
+    if func is None:
+        return _out_func
+    return _out_func(func)
 
 
 def _run_in_thread(

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -1,0 +1,62 @@
+# https://gist.github.com/FlorianRhiem/41a1ad9b694c14fb9ac3
+
+from superqt.qtcompat.QtCore import (
+    QCoreApplication,
+    QEventLoop,
+    QMetaObject,
+    QObject,
+    Qt,
+    QThread,
+    QTimer,
+    Signal,
+    Slot,
+)
+
+
+class CallCallable(QObject):
+    finished = Signal(object)
+    instances = []
+
+    def __init__(self, callable, *args, **kwargs):
+        super().__init__()
+        self._callable = callable
+        self._args = args
+        self._kwargs = kwargs
+        CallCallable.instances.append(self)
+
+    @Slot
+    def call(self):
+        CallCallable.instances.remove(self)
+        res = self._callable(*self._args, **self._kwargs)
+        self.finished.emit(res)
+
+
+def ensure_main_thread(func, no_return=True, timeout=1000):
+    def _func(*args, **kwargs):
+        if QCoreApplication.instance().thread() == QThread.currentThread():
+            return func(*args, **kwargs)
+        f = CallCallable(func, *args, **kwargs)
+        f.moveToThread(QCoreApplication.instance().thread())
+        if no_return:
+            QMetaObject.invokeMethod(f, "call", Qt.QueuedConnection)
+            return
+
+        res = []
+
+        def set_res(data):
+            res.append(data)
+
+        f.finished.connect(set_res)
+        timer = QTimer()
+        timer.setSingleShot(True)
+        loop = QEventLoop()
+        f.finished.connect(loop.quit)
+        timer.timeout.connect(loop.quit)
+        timer.start(timeout)
+        QMetaObject.invokeMethod(f, "call", Qt.QueuedConnection)
+        loop.exec_()
+        if len(res) == 0:
+            raise TimeoutError("Not recived value")
+        return res[0]
+
+    return _func

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -1,0 +1,111 @@
+import time
+
+from superqt.qtcompat.QtCore import QCoreApplication, QObject, QThread, Signal
+from superqt.utils import ensure_main_thread, ensure_object_thread
+
+
+class SampleObject(QObject):
+    assigment_done = Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.main_thread_res = {}
+        self.object_thread_res = {}
+
+    def long_wait(self):
+        time.sleep(1)
+
+    @ensure_main_thread()
+    def check_main_thread(self, a, *, b=1):
+        if QThread.currentThread() is not QCoreApplication.instance().thread():
+            raise RuntimeError("Wrong thread")
+        self.main_thread_res = {"a": a, "b": b}
+        self.assigment_done.emit()
+
+    @ensure_object_thread()
+    def check_object_thread(self, a, *, b=1):
+        if QThread.currentThread() is not self.thread():
+            raise RuntimeError("Wrong thread")
+        self.object_thread_res = {"a": a, "b": b}
+        self.assigment_done.emit()
+
+    @ensure_object_thread(no_return=False)
+    def check_object_thread_return(self, a):
+        if QThread.currentThread() is not self.thread():
+            raise RuntimeError("Wrong thread")
+        return a * 7
+
+    @ensure_main_thread(no_return=False)
+    def check_main_thread_return(self, a):
+        if QThread.currentThread() is not QCoreApplication.instance().thread():
+            raise RuntimeError("Wrong thread")
+        return a * 8
+
+
+class LocalThread(QThread):
+    def __init__(self, ob):
+        super().__init__()
+        self.ob = ob
+
+    def run(self):
+        assert QThread.currentThread() is not QCoreApplication.instance().thread()
+        self.ob.check_main_thread(5, b=8)
+
+
+class LocalThread2(QThread):
+    def __init__(self, ob):
+        super().__init__()
+        self.ob = ob
+        self.executed = False
+
+    def run(self):
+        assert QThread.currentThread() is not QCoreApplication.instance().thread()
+        assert self.ob.check_main_thread_return(5) == 40
+        self.executed = True
+
+
+def test_only_main_thread(qapp):
+    ob = SampleObject()
+    ob.check_main_thread(1, b=3)
+    assert ob.main_thread_res == {"a": 1, "b": 3}
+    ob.check_object_thread(2, b=4)
+    assert ob.object_thread_res == {"a": 2, "b": 4}
+
+
+def test_object_thread(qtbot):
+    ob = SampleObject()
+    thread = QThread()
+    thread.start()
+    ob.moveToThread(thread)
+    with qtbot.waitSignal(ob.assigment_done):
+        ob.check_object_thread(2, b=4)
+    assert ob.thread() is thread
+    thread.exit(0)
+    assert ob.object_thread_res == {"a": 2, "b": 4}
+
+
+def test_main_thread(qtbot):
+    ob = SampleObject()
+    t = LocalThread(ob)
+    with qtbot.waitSignal(ob.assigment_done, timeout=10000000):
+        t.start()
+
+    assert ob.main_thread_res == {"a": 5, "b": 8}
+
+
+def test_object_thread_return(qtbot):
+    ob = SampleObject()
+    thread = QThread()
+    thread.start()
+    ob.moveToThread(thread)
+    assert ob.check_object_thread_return(2) == 14
+    assert ob.thread() is thread
+    thread.exit(0)
+
+
+def test_main_thread_return(qtbot):
+    ob = SampleObject()
+    t = LocalThread2(ob)
+    with qtbot.wait_signal(t.finished):
+        t.start()
+    assert t.executed

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -11,9 +11,35 @@ class SampleObject(QObject):
         super().__init__()
         self.main_thread_res = {}
         self.object_thread_res = {}
+        self.main_thread_prop_val = None
+        self.sample_thread_prop_val = None
 
     def long_wait(self):
         time.sleep(1)
+
+    @property
+    def sample_main_thread_property(self):
+        return self.main_thread_prop_val
+
+    @sample_main_thread_property.setter
+    @ensure_main_thread()
+    def sample_main_thread_property(self, value):
+        if QThread.currentThread() is not QCoreApplication.instance().thread():
+            raise RuntimeError("Wrong thread")
+        self.main_thread_prop_val = value
+        self.assigment_done.emit()
+
+    @property
+    def sample_object_thread_property(self):
+        return self.sample_thread_prop_val
+
+    @sample_object_thread_property.setter
+    @ensure_object_thread()
+    def sample_object_thread_property(self, value):
+        if QThread.currentThread() is not self.thread():
+            raise RuntimeError("Wrong thread")
+        self.sample_thread_prop_val = value
+        self.assigment_done.emit()
 
     @ensure_main_thread()
     def check_main_thread(self, a, *, b=1):
@@ -50,6 +76,7 @@ class LocalThread(QThread):
     def run(self):
         assert QThread.currentThread() is not QCoreApplication.instance().thread()
         self.ob.check_main_thread(5, b=8)
+        self.ob.main_thread_prop_val = "text2"
 
 
 class LocalThread2(QThread):
@@ -70,6 +97,10 @@ def test_only_main_thread(qapp):
     assert ob.main_thread_res == {"a": 1, "b": 3}
     ob.check_object_thread(2, b=4)
     assert ob.object_thread_res == {"a": 2, "b": 4}
+    ob.sample_main_thread_property = 5
+    assert ob.sample_main_thread_property == 5
+    ob.sample_object_thread_property = 7
+    assert ob.sample_object_thread_property == 7
 
 
 def test_object_thread(qtbot):
@@ -79,18 +110,24 @@ def test_object_thread(qtbot):
     ob.moveToThread(thread)
     with qtbot.waitSignal(ob.assigment_done):
         ob.check_object_thread(2, b=4)
+    assert ob.object_thread_res == {"a": 2, "b": 4}
+
+    with qtbot.waitSignal(ob.assigment_done):
+        ob.sample_object_thread_property = "text"
+
+    assert ob.sample_object_thread_property == "text"
     assert ob.thread() is thread
     thread.exit(0)
-    assert ob.object_thread_res == {"a": 2, "b": 4}
 
 
 def test_main_thread(qtbot):
     ob = SampleObject()
     t = LocalThread(ob)
-    with qtbot.waitSignal(ob.assigment_done, timeout=10000000):
+    with qtbot.waitSignal(t.finished, timeout=10000000):
         t.start()
 
     assert ob.main_thread_res == {"a": 5, "b": 8}
+    assert ob.sample_main_thread_property == "text2"
 
 
 def test_object_thread_return(qtbot):

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -123,7 +123,7 @@ def test_object_thread(qtbot):
 def test_main_thread(qtbot):
     ob = SampleObject()
     t = LocalThread(ob)
-    with qtbot.waitSignal(t.finished, timeout=10000000):
+    with qtbot.waitSignal(t.finished):
         t.start()
 
     assert ob.main_thread_res == {"a": 5, "b": 8}

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -41,14 +41,14 @@ class SampleObject(QObject):
         self.sample_thread_prop_val = value
         self.assigment_done.emit()
 
-    @ensure_main_thread()
+    @ensure_main_thread
     def check_main_thread(self, a, *, b=1):
         if QThread.currentThread() is not QCoreApplication.instance().thread():
             raise RuntimeError("Wrong thread")
         self.main_thread_res = {"a": a, "b": b}
         self.assigment_done.emit()
 
-    @ensure_object_thread()
+    @ensure_object_thread
     def check_object_thread(self, a, *, b=1):
         if QThread.currentThread() is not self.thread():
             raise RuntimeError("Wrong thread")

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -55,13 +55,13 @@ class SampleObject(QObject):
         self.object_thread_res = {"a": a, "b": b}
         self.assigment_done.emit()
 
-    @ensure_object_thread(no_return=False)
+    @ensure_object_thread(await_return=True)
     def check_object_thread_return(self, a):
         if QThread.currentThread() is not self.thread():
             raise RuntimeError("Wrong thread")
         return a * 7
 
-    @ensure_main_thread(no_return=False)
+    @ensure_main_thread(await_return=True)
     def check_main_thread_return(self, a):
         if QThread.currentThread() is not QCoreApplication.instance().thread():
             raise RuntimeError("Wrong thread")


### PR DESCRIPTION
This PR adds two decorators:

* `ensure_main_tread` - force to function/method will be called in main thread.\
* `ensure_object_thread` - force to method of `QObject` instance to be executed in this object thread. 

## TODO 
* [x] implement decorators
* [x] add test for function calling
* [x] check if it works with `@property` 
* [x] add documentation