### PR TITLE
Add type stubs for ensure_thread decorator

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
 include README.md
-
+include superqt/py.typed
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE
 include README.md
 include superqt/py.typed
+recursive-include superqt *.py
+recursive-include superqt *.pyi
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,9 @@ testing =
     tox
     tox-conda
 
+[options.package_data]
+superqt = py.typed
+
 [flake8]
 exclude = _version.py,.eggs,examples
 docstring-convention = numpy

--- a/superqt/sliders/__init__.pyi
+++ b/superqt/sliders/__init__.pyi
@@ -1,8 +1,7 @@
-from PyQt5.QtWidgets import QSlider
+from superqt.qtcompat.QtWidgets import QSlider
 
 from ._generic_range_slider import _GenericRangeSlider
 from ._generic_slider import _GenericSlider
-from .qtcompat.QtWidgets import QSlider
 
 class QDoubleRangeSlider(_GenericRangeSlider): ...
 class QDoubleSlider(_GenericSlider): ...

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -108,7 +108,7 @@ def _run_in_thread(
     *args,
     **kwargs,
 ):
-    future = Future()
+    future = Future()  # type: ignore
     if thread is QThread.currentThread():
         result = func(*args, **kwargs)
         if not await_return:

--- a/superqt/utils/_ensure_thread.pyi
+++ b/superqt/utils/_ensure_thread.pyi
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-from typing import Any, Callable, List, Optional, TypeVar, overload
+from typing import Callable, TypeVar, overload
 
 from typing_extensions import Literal, ParamSpec
 

--- a/superqt/utils/_ensure_thread.pyi
+++ b/superqt/utils/_ensure_thread.pyi
@@ -1,0 +1,52 @@
+from concurrent.futures import Future
+from typing import Any, Callable, List, Optional, TypeVar, overload
+
+from typing_extensions import Literal, ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+@overload
+def ensure_main_thread(
+    await_return: Literal[True],
+    timeout: int = 1000,
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+@overload
+def ensure_main_thread(
+    func: Callable[P, R],
+    await_return: Literal[True],
+    timeout: int = 1000,
+) -> Callable[P, R]: ...
+@overload
+def ensure_main_thread(
+    await_return: Literal[False] = False,
+    timeout: int = 1000,
+) -> Callable[[Callable[P, R]], Callable[P, Future[R]]]: ...
+@overload
+def ensure_main_thread(
+    func: Callable[P, R],
+    await_return: Literal[False] = False,
+    timeout: int = 1000,
+) -> Callable[P, Future[R]]: ...
+@overload
+def ensure_object_thread(
+    await_return: Literal[True],
+    timeout: int = 1000,
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+@overload
+def ensure_object_thread(
+    func: Callable[P, R],
+    await_return: Literal[True],
+    timeout: int = 1000,
+) -> Callable[P, R]: ...
+@overload
+def ensure_object_thread(
+    await_return: Literal[False] = False,
+    timeout: int = 1000,
+) -> Callable[[Callable[P, R]], Callable[P, Future[R]]]: ...
+@overload
+def ensure_object_thread(
+    func: Callable[P, R],
+    await_return: Literal[False] = False,
+    timeout: int = 1000,
+) -> Callable[P, Future[R]]: ...


### PR DESCRIPTION
Since inline stubs for decorators with optional arguments that modify return params get a little ugly, i figure it makes more sense to put them in a stub file...  this adds stubs for `ensure_main_thread` and `ensure_object_thread`.  cc @Czaki 