### PR TITLE
Propagate function name in `ensure_main_thread` and `ensure_object_thread`

### DIFF
--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -63,6 +63,7 @@ def ensure_main_thread(
 
         if hasattr(func, "__name__"):
             _func.__name__ = func.__name__
+        _func.__wrapped__ = func
 
         return _func
 
@@ -98,6 +99,7 @@ def ensure_object_thread(
 
         if hasattr(func, "__name__"):
             _func.__name__ = func.__name__
+        _func.__wrapped__ = func
 
         return _func
 

--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -61,6 +61,9 @@ def ensure_main_thread(
                 **kwargs,
             )
 
+        if hasattr(func, "__name__"):
+            _func.__name__ = func.__name__
+
         return _func
 
     if func is None:
@@ -92,6 +95,9 @@ def ensure_object_thread(
             return _run_in_thread(
                 func, self.thread(), await_return, timeout, self, *args, **kwargs
             )
+
+        if hasattr(func, "__name__"):
+            _func.__name__ = func.__name__
 
         return _func
 

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -184,3 +184,18 @@ def test_main_thread_return(qtbot):
     with qtbot.wait_signal(t.finished):
         t.start()
     assert t.executed
+
+
+def test_names(qtbot):
+    ob = SampleObject()
+    assert ob.check_object_thread.__name__ == "check_object_thread"
+    assert ob.check_object_thread_return.__name__ == "check_object_thread_return"
+    assert (
+        ob.check_object_thread_return_timeout.__name__
+        == "check_object_thread_return_timeout"
+    )
+    assert (
+        ob.check_object_thread_return_future.__name__
+        == "check_object_thread_return_future"
+    )
+    assert ob.check_main_thread_return.__name__ == "check_main_thread_return"


### PR DESCRIPTION
This is `superqt` side of the fix bug mentioned in https://github.com/napari/napari/pull/3445. 

Without this fix following code will pass:

```python
class Test(Qobject):
	@ensure_object_thread
	def test_func(self, arg1):
		pass

t = Test()

assert t.test_func.__name__ == "_func"
```

