### PR TITLE
Add qt_set_trace and install_qt_breakpoint

### DIFF
--- a/src/superqt/utils/__init__.py
+++ b/src/superqt/utils/__init__.py
@@ -8,8 +8,12 @@ __all__ = (
     "QMessageHandler",
     "thread_worker",
     "WorkerBase",
+    "install_qt_breakpoint",
+    "uninstall_qt_breakpoint",
+    "qt_set_trace",
 )
 
+from ._breakpoint import qt_set_trace
 from ._ensure_thread import ensure_main_thread, ensure_object_thread
 from ._message_handler import QMessageHandler
 from ._qthreading import (

--- a/src/superqt/utils/_breakpoint.py
+++ b/src/superqt/utils/_breakpoint.py
@@ -1,0 +1,42 @@
+import pdb  # noqa
+import sys
+from types import FrameType
+from typing import Optional
+
+from superqt.qtcompat import QtCore
+from superqt.qtcompat.QtWidgets import QApplication
+
+
+class QtPdb(pdb.Pdb):
+    def set_trace(self, frame: Optional[FrameType] = None) -> None:
+        QApplication.processEvents()
+        if hasattr(QtCore, "pyqtRemoveInputHook"):
+            QtCore.pyqtRemoveInputHook()
+        super().set_trace(frame)
+
+    def set_continue(self) -> None:
+        super().set_continue()
+        if hasattr(QtCore, "pyqtRestoreInputHook"):
+            QtCore.pyqtRestoreInputHook()
+
+    def set_quit(self) -> None:
+        app = QApplication.instance()
+        if app is not None:
+            print("exit")
+            app.exit()
+        super().set_quit()
+
+
+def qt_set_trace(*, header: Optional[str] = None) -> None:
+    pdb = QtPdb()
+    if header is not None:
+        pdb.message(header)
+    pdb.set_trace(sys._getframe().f_back)
+
+
+def install_qtbreakpoint() -> None:
+    sys.breakpointhook = qt_set_trace
+
+
+def uninstall_qtbreakpoint() -> None:
+    sys.breakpointhook = sys.__breakpointhook__


### PR DESCRIPTION
This PR adds a few conveniences around using a debugger with Qt.

to add a breakpoint in Qt code, use it like `pdb.set_trace()`

```py
from superqt.utils import qt_set_trace; qt_set_trace()
```

This will stop the event loop so you don't get an endless chain of 
```
QCoreApplication::exec: The event loop is already running
QCoreApplication::exec: The event loop is already running
QCoreApplication::exec: The event loop is already running
```

or to permanently install it so that you can use the builtin `breakpoint()` anywhere

```py
from superqt.utils import install_qt_breakpoint

install_qt_breakpoint()
```


