### PR TITLE
reskip test_object_thread_return on ci

### DIFF
--- a/tests/test_ensure_thread.py
+++ b/tests/test_ensure_thread.py
@@ -165,7 +165,7 @@ def test_names(qapp):
     assert ob.check_main_thread_return.__name__ == "check_main_thread_return"
 
 
-# @skip_on_ci
+@skip_on_ci
 def test_object_thread_return(qtbot):
     ob = SampleObject()
     thread = QThread()
@@ -177,7 +177,7 @@ def test_object_thread_return(qtbot):
         thread.quit()
 
 
-# @skip_on_ci
+@skip_on_ci
 def test_object_thread_return_timeout(qtbot):
     ob = SampleObject()
     thread = QThread()


### PR DESCRIPTION
somehow the skip got commented out... and tests are hanging