### PR TITLE
Fix nested threadworker not starting

### DIFF
--- a/tests/test_threadworker.py
+++ b/tests/test_threadworker.py
@@ -3,6 +3,7 @@ import time
 import warnings
 from functools import partial
 from operator import eq
+from unittest.mock import Mock
 
 import pytest
 
@@ -274,3 +275,20 @@ def test_abort_does_not_return(qtbot):
     assert loop_counter < 4
     assert abort_counter == 1
     assert return_counter == 0
+
+
+def test_nested_threads_start(qtbot):
+    mock1 = Mock()
+    mock2 = Mock()
+
+    def call_mock():
+        mock1()
+        worker2 = qthreading.create_worker(mock2)
+        worker2.start()
+
+    worker = qthreading.create_worker(call_mock)
+    worker.start()
+
+    qtbot.wait(20)
+    mock1.assert_called_once()
+    mock2.assert_called_once()


### PR DESCRIPTION
fixes napari/superqt#64

Threadworkers started within another thread weren't getting started because of the QTimer.singleshot call in the QRunnable.start method.  (because threads don't have event loops, and QTimer needs one).  This checks to see if we're running in a thread that has an event loop before queuing with QTimer, otherwise it starts the runnable immediately)