### PR TITLE
Fix CSS for Collapsible

### DIFF
--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -28,7 +28,7 @@ class QCollapsible(QFrame):
 
         self._toggle_btn = QPushButton(self._COLLAPSED + title)
         self._toggle_btn.setCheckable(True)
-        self._toggle_btn.setStyleSheet("text-align: left; background: transparent;")
+        self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
         self._toggle_btn.toggled.connect(self._toggle)
 
         # frame layout


### PR DESCRIPTION
The button used for the Collapsible previously showed a black on
archlinux.
This fixes it to display properly.
Collapsilbe before fix:
![image](https://user-images.githubusercontent.com/25890405/163693811-47962b98-baa9-45ac-81d9-f4db423b3cf5.png)

Collapsilbe after fix:
![image](https://user-images.githubusercontent.com/25890405/163693807-c7dd57ce-f26d-4e99-a469-5e2747bf85f7.png)


Closes https://github.com/napari/superqt/issues/78