### PR TITLE
QCheckComboBox for Easy Item Selection in ComboBox

### DIFF
--- a/examples/check_combobox.py
+++ b/examples/check_combobox.py
@@ -1,0 +1,39 @@
+from qtpy.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QPushButton, QWidget
+from src.superqt import QCheckComboBox
+
+
+def change_label_type()->None:
+    """Function used to swtich the label type"""
+    if combobox.labelType() == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
+        combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.STRING)
+        combobox.setLabelText("Select Sample")
+    else:
+        combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+
+# Create main window
+app = QApplication([])
+main_window = QMainWindow()
+main_widget = QWidget()
+main_layout = QVBoxLayout()
+main_window.setFixedWidth(700)
+main_window.setFixedHeight(450)
+
+# Create the check comobobox
+combobox = QCheckComboBox()
+combobox.setLabelText("Select items")
+texts = [f"Item {i}" for i in range(5)]
+combobox.addItems(texts)
+
+# Add button to change the label type
+button = QPushButton("Change label type")
+button.clicked.connect(lambda :change_label_type())
+
+# Add widgets to main window
+main_widget.setLayout(main_layout)
+main_widget.layout().addWidget(combobox)
+main_widget.layout().addWidget(button)
+main_window.setCentralWidget(main_widget)
+main_window.show()
+
+# Run
+app.exec_()

--- a/examples/check_combobox.py
+++ b/examples/check_combobox.py
@@ -1,14 +1,16 @@
-from qtpy.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QPushButton, QWidget
+from qtpy.QtWidgets import QApplication, QMainWindow, QPushButton, QVBoxLayout, QWidget
+
 from src.superqt import QCheckComboBox
 
 
-def change_label_type()->None:
+def change_label_type() -> None:
     """Function used to swtich the label type"""
     if combobox.labelType() == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
         combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.STRING)
         combobox.setLabelText("Select Sample")
     else:
         combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+
 
 # Create main window
 app = QApplication([])
@@ -26,7 +28,7 @@ combobox.addItems(texts)
 
 # Add button to change the label type
 button = QPushButton("Change label type")
-button.clicked.connect(lambda :change_label_type())
+button.clicked.connect(lambda: change_label_type())
 
 # Add widgets to main window
 main_widget.setLayout(main_layout)

--- a/src/superqt/__init__.py
+++ b/src/superqt/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from ._eliding_label import QElidingLabel
 from .collapsible import QCollapsible
-from .combobox import QEnumComboBox, QSearchableComboBox, QCheckComboBox
+from .combobox import QCheckComboBox, QEnumComboBox, QSearchableComboBox
 from .selection import QSearchableListWidget
 from .sliders import (
     QDoubleRangeSlider,

--- a/src/superqt/__init__.py
+++ b/src/superqt/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from ._eliding_label import QElidingLabel
 from .collapsible import QCollapsible
-from .combobox import QEnumComboBox, QSearchableComboBox
+from .combobox import QEnumComboBox, QSearchableComboBox, QCheckComboBox
 from .selection import QSearchableListWidget
 from .sliders import (
     QDoubleRangeSlider,
@@ -24,6 +24,7 @@ from .utils import QMessageHandler, ensure_main_thread, ensure_object_thread
 __all__ = [
     "ensure_main_thread",
     "ensure_object_thread",
+    "QCheckComboBox",
     "QDoubleRangeSlider",
     "QDoubleSlider",
     "QElidingLabel",

--- a/src/superqt/combobox/__init__.py
+++ b/src/superqt/combobox/__init__.py
@@ -1,4 +1,5 @@
 from ._enum_combobox import QEnumComboBox
 from ._searchable_combo_box import QSearchableComboBox
+from ._check_combobox import QCheckComboBox
 
-__all__ = ("QEnumComboBox", "QSearchableComboBox")
+__all__ = ("QEnumComboBox", "QSearchableComboBox", "QCheckComboBox")

--- a/src/superqt/combobox/__init__.py
+++ b/src/superqt/combobox/__init__.py
@@ -1,5 +1,5 @@
+from ._check_combobox import QCheckComboBox
 from ._enum_combobox import QEnumComboBox
 from ._searchable_combo_box import QSearchableComboBox
-from ._check_combobox import QCheckComboBox
 
 __all__ = ("QEnumComboBox", "QSearchableComboBox", "QCheckComboBox")

--- a/src/superqt/combobox/_check_combobox.py
+++ b/src/superqt/combobox/_check_combobox.py
@@ -1,0 +1,130 @@
+
+from enum import Enum, auto
+from typing import Any, Union
+from qtpy.QtCore import QEvent, Qt
+from qtpy.QtGui import QStandardItem
+from qtpy.QtWidgets import QComboBox, QStyle, QStyleOptionComboBox, QStylePainter
+
+
+class QCheckComboBox(QComboBox):
+    """
+    A combobox with a check for each item inserted.
+    based on https://stackoverflow.com/questions/47575880/qcombobox-set-title-text-regardless-of-items
+    """
+
+    class QCheckComboBoxLabelType(Enum):
+        """Label type"""
+        STRING = auto()
+        SELECTED_ITEMS = auto()
+
+    _label_text:str = "Select items"
+    _label_type:QCheckComboBoxLabelType = QCheckComboBoxLabelType.STRING
+
+    def __init__(self)->None:
+        """Initializes the widget"""
+        super().__init__()
+        self.view().pressed.connect(self._handleItemPressed)
+        self._changed = False
+
+    def _update_label_text_with_selected_items(self)->None:
+        checked_indices = self.checkedIndices()
+        selected_text_list = []
+        for index in checked_indices:
+            selected_text_list.append(self.itemText(index))
+        self.setLabelText(", ".join(selected_text_list))
+
+    def setLabelText(self, label_text:str)->None:
+        """Sets the label text"""
+        self._label_text = label_text
+        self.repaint()
+    
+    def labelText(self)->str:
+        return self._label_text
+
+    def  setLabelType(self, label_type:QCheckComboBoxLabelType)->None:
+        """Sets the label type"""
+        self._label_type = label_type
+        if label_type==QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
+            self._update_label_text_with_selected_items()
+
+    def labelType(self)->QCheckComboBoxLabelType:
+        """Returns label type"""
+        return self._label_type
+
+    def _handleItemPressed(self, index:int)->None:
+        """Updates item checked status"""
+        item = self.model().itemFromIndex(index)
+        if item.checkState() == Qt.Checked:
+            item.setCheckState(Qt.Unchecked)
+        else:
+            item.setCheckState(Qt.Checked)
+        
+        if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
+            self._update_label_text_with_selected_items()
+        self._changed = True
+
+    def addItem(self, text: str, userData:Any=None, checked:bool=True) -> None:
+        """Overrides the combobox additem to make sure it is chackable"""
+        super().addItem(text, userData)
+        item:QStandardItem = self.model().item(self.count()-1, self.modelColumn())
+        item.setCheckable(True)
+        self.setItemChecked(self.count()-1, checked=checked)
+        if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS and checked==True: 
+            self._update_label_text_with_selected_items() 
+
+    def addItems(self, texts:list[str], checked:Union[bool, list[bool]]=True) -> None:
+        """Overirdes the combobox addItems to make sure it is checkable"""
+        if isinstance(checked, bool):
+            checked = [checked] * len(texts)
+
+        for text, checked_value in zip(texts, checked):
+            self.addItem(text=text, userData=None, checked=checked_value)
+
+        if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS and any(checked)==True: 
+            self._update_label_text_with_selected_items() 
+
+    def hidePopup(self)->None:
+        """Override hidePopup to disable it if an item state has changed"""
+        if not self._changed:
+            super().hidePopup()
+        self._changed = False
+
+    def itemChecked(self, index:int) -> bool:
+        """Returns current checked state as boolean"""
+        item:QStandardItem = self.model().item(index, self.modelColumn())
+        is_checked:bool = item.checkState() == Qt.Checked
+        return is_checked
+
+    def setItemChecked(self, index:int, checked:bool=True)->None:
+        """Sets the status """
+        item:QStandardItem = self.model().item(index, self.modelColumn())
+        if checked:
+            item.setCheckState(Qt.Checked)
+        else:
+            item.setCheckState(Qt.Unchecked)
+
+    def setAllItemChecked(self, checked:bool=True)->None:
+        """Set all item checked status in one go"""
+        for i in range(self.count()):
+            self.setItemChecked(i, checked=checked)
+
+    def checkedIndices(self)->list[int]:
+        """Returns the checked indices"""
+        model_indices = self.model().match(self.model().index(0,0), Qt.CheckStateRole, Qt.Checked, -1, Qt.MatchRecursive)
+        indecies = [model_index.row() for model_index in model_indices]
+        return indecies
+
+    def uncheckedIndices(self)->list[int]:
+        """Returns teh unchecked indices"""
+        model_indices = self.model().match(self.model().index(0,0), Qt.CheckStateRole, Qt.Unchecked, -1, Qt.MatchRecursive)
+        indices = [model_index.row() for model_index in model_indices]
+        return indices
+
+    def paintEvent(self, event:QEvent)->None:
+        """Overrides the paint event to update the label"""
+        painter = QStylePainter(self)
+        opt = QStyleOptionComboBox()
+        self.initStyleOption(opt)
+        opt.currentText = self._label_text
+        painter.drawComplexControl(QStyle.CC_ComboBox, opt)
+        painter.drawControl(QStyle.CE_ComboBoxLabel, opt)

--- a/src/superqt/combobox/_check_combobox.py
+++ b/src/superqt/combobox/_check_combobox.py
@@ -1,6 +1,6 @@
-
 from enum import Enum, auto
 from typing import Any, Union
+
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QStandardItem
 from qtpy.QtWidgets import QComboBox, QStyle, QStyleOptionComboBox, QStylePainter
@@ -14,65 +14,71 @@ class QCheckComboBox(QComboBox):
 
     class QCheckComboBoxLabelType(Enum):
         """Label type"""
+
         STRING = auto()
         SELECTED_ITEMS = auto()
 
-    _label_text:str = "Select items"
-    _label_type:QCheckComboBoxLabelType = QCheckComboBoxLabelType.STRING
+    _label_text: str = "Select items"
+    _label_type: QCheckComboBoxLabelType = QCheckComboBoxLabelType.STRING
 
-    def __init__(self)->None:
+    def __init__(self) -> None:
         """Initializes the widget"""
         super().__init__()
         self.view().pressed.connect(self._handleItemPressed)
         self._changed = False
 
-    def _update_label_text_with_selected_items(self)->None:
+    def _update_label_text_with_selected_items(self) -> None:
         checked_indices = self.checkedIndices()
         selected_text_list = []
         for index in checked_indices:
             selected_text_list.append(self.itemText(index))
         self.setLabelText(", ".join(selected_text_list))
 
-    def setLabelText(self, label_text:str)->None:
+    def setLabelText(self, label_text: str) -> None:
         """Sets the label text"""
         self._label_text = label_text
         self.repaint()
-    
-    def labelText(self)->str:
+
+    def labelText(self) -> str:
         return self._label_text
 
-    def  setLabelType(self, label_type:QCheckComboBoxLabelType)->None:
+    def setLabelType(self, label_type: QCheckComboBoxLabelType) -> None:
         """Sets the label type"""
         self._label_type = label_type
-        if label_type==QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
+        if label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
             self._update_label_text_with_selected_items()
 
-    def labelType(self)->QCheckComboBoxLabelType:
+    def labelType(self) -> QCheckComboBoxLabelType:
         """Returns label type"""
         return self._label_type
 
-    def _handleItemPressed(self, index:int)->None:
+    def _handleItemPressed(self, index: int) -> None:
         """Updates item checked status"""
         item = self.model().itemFromIndex(index)
         if item.checkState() == Qt.Checked:
             item.setCheckState(Qt.Unchecked)
         else:
             item.setCheckState(Qt.Checked)
-        
+
         if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS:
             self._update_label_text_with_selected_items()
         self._changed = True
 
-    def addItem(self, text: str, userData:Any=None, checked:bool=True) -> None:
+    def addItem(self, text: str, userData: Any = None, checked: bool = True) -> None:
         """Overrides the combobox additem to make sure it is chackable"""
         super().addItem(text, userData)
-        item:QStandardItem = self.model().item(self.count()-1, self.modelColumn())
+        item: QStandardItem = self.model().item(self.count() - 1, self.modelColumn())
         item.setCheckable(True)
-        self.setItemChecked(self.count()-1, checked=checked)
-        if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS and checked==True: 
-            self._update_label_text_with_selected_items() 
+        self.setItemChecked(self.count() - 1, checked=checked)
+        if (
+            self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS
+            and checked is True
+        ):
+            self._update_label_text_with_selected_items()
 
-    def addItems(self, texts:list[str], checked:Union[bool, list[bool]]=True) -> None:
+    def addItems(
+        self, texts: list[str], checked: Union[bool, list[bool]] = True
+    ) -> None:
         """Overirdes the combobox addItems to make sure it is checkable"""
         if isinstance(checked, bool):
             checked = [checked] * len(texts)
@@ -80,47 +86,62 @@ class QCheckComboBox(QComboBox):
         for text, checked_value in zip(texts, checked):
             self.addItem(text=text, userData=None, checked=checked_value)
 
-        if self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS and any(checked)==True: 
-            self._update_label_text_with_selected_items() 
+        if (
+            self._label_type == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS
+            and any(checked) is True
+        ):
+            self._update_label_text_with_selected_items()
 
-    def hidePopup(self)->None:
+    def hidePopup(self) -> None:
         """Override hidePopup to disable it if an item state has changed"""
         if not self._changed:
             super().hidePopup()
         self._changed = False
 
-    def itemChecked(self, index:int) -> bool:
+    def itemChecked(self, index: int) -> bool:
         """Returns current checked state as boolean"""
-        item:QStandardItem = self.model().item(index, self.modelColumn())
-        is_checked:bool = item.checkState() == Qt.Checked
+        item: QStandardItem = self.model().item(index, self.modelColumn())
+        is_checked: bool = item.checkState() == Qt.Checked
         return is_checked
 
-    def setItemChecked(self, index:int, checked:bool=True)->None:
-        """Sets the status """
-        item:QStandardItem = self.model().item(index, self.modelColumn())
+    def setItemChecked(self, index: int, checked: bool = True) -> None:
+        """Sets the status"""
+        item: QStandardItem = self.model().item(index, self.modelColumn())
         if checked:
             item.setCheckState(Qt.Checked)
         else:
             item.setCheckState(Qt.Unchecked)
 
-    def setAllItemChecked(self, checked:bool=True)->None:
+    def setAllItemChecked(self, checked: bool = True) -> None:
         """Set all item checked status in one go"""
         for i in range(self.count()):
             self.setItemChecked(i, checked=checked)
 
-    def checkedIndices(self)->list[int]:
+    def checkedIndices(self) -> list[int]:
         """Returns the checked indices"""
-        model_indices = self.model().match(self.model().index(0,0), Qt.CheckStateRole, Qt.Checked, -1, Qt.MatchRecursive)
+        model_indices = self.model().match(
+            self.model().index(0, 0),
+            Qt.CheckStateRole,
+            Qt.Checked,
+            -1,
+            Qt.MatchRecursive,
+        )
         indecies = [model_index.row() for model_index in model_indices]
         return indecies
 
-    def uncheckedIndices(self)->list[int]:
+    def uncheckedIndices(self) -> list[int]:
         """Returns teh unchecked indices"""
-        model_indices = self.model().match(self.model().index(0,0), Qt.CheckStateRole, Qt.Unchecked, -1, Qt.MatchRecursive)
+        model_indices = self.model().match(
+            self.model().index(0, 0),
+            Qt.CheckStateRole,
+            Qt.Unchecked,
+            -1,
+            Qt.MatchRecursive,
+        )
         indices = [model_index.row() for model_index in model_indices]
         return indices
 
-    def paintEvent(self, event:QEvent)->None:
+    def paintEvent(self, event: QEvent) -> None:
         """Overrides the paint event to update the label"""
         painter = QStylePainter(self)
         opt = QStyleOptionComboBox()

--- a/tests/test_check_combobox.py
+++ b/tests/test_check_combobox.py
@@ -1,0 +1,108 @@
+from tabnanny import check
+from superqt import QCheckComboBox
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import QEvent
+
+def test_add_item(qtbot:QtBot)->None:
+    """Tests the addition of item"""
+
+    check_combobox = QCheckComboBox()
+
+    check_combobox.addItem("Item 1", userData=1, checked=False)
+    check_combobox.addItem("Item 2", userData="2", checked=True)
+
+    assert(check_combobox.itemData(0)==1)
+    assert(check_combobox.itemData(1)=="2")
+    assert(check_combobox.itemText(0)=="Item 1")
+    assert(check_combobox.itemText(1)=="Item 2")
+
+def test_add_items(qtbot:QtBot)->None:
+    """Tests the addition of items"""
+
+    check_combobox1 = QCheckComboBox()
+    check_combobox1.addItems(["Item 1", "Item 2", "Item 3"])
+    assert(check_combobox1.itemText(0)=="Item 1")
+    assert(check_combobox1.itemText(1)=="Item 2")
+    assert(check_combobox1.itemText(2)=="Item 3")
+
+    check_combobox2 = QCheckComboBox()
+    check_combobox2.addItems(["Item 1", "Item 2"], checked=False)
+    assert(check_combobox2.itemChecked(0)==False)
+    assert(check_combobox2.itemChecked(1)==False)
+
+    check_combobox3 = QCheckComboBox()
+    check_combobox3.addItems(["Item 1", "Item 2"], checked=True)
+    assert(check_combobox3.itemChecked(0)==True)
+    assert(check_combobox3.itemChecked(1)==True)
+
+    check_combobox4 = QCheckComboBox()
+    check_combobox4.addItems(["Item 1", "Item 2"], checked=[True, False])
+    assert(check_combobox4.itemChecked(0)==True)
+    assert(check_combobox4.itemChecked(1)==False)
+
+
+def test_set_all_items_checked(qtbot:QtBot)->None:
+    """Tests setting all items checked status"""
+    check_combobox = QCheckComboBox()
+    check_combobox.addItems(["Item 1", "Item 2", "Item 3"], checked=[True, False, True])
+    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
+    assert(checked_status == [True, False, True])
+
+    check_combobox.setAllItemChecked(False)
+    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
+    assert(checked_status == [False, False, False])
+
+    check_combobox.setAllItemChecked(True)
+    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
+    assert(checked_status == [True, True, True])
+
+def test_indices_retrival(qtbot:QtBot)->None:
+    """Tests retrival of the indices checked and unchecked"""
+    check_combobox = QCheckComboBox()
+    check_combobox.addItems(["Item 1", "Item 2", "Item 3"], checked=[True, False, True])
+    assert(check_combobox.checkedIndices()==[0,2])
+    assert(check_combobox.uncheckedIndices()==[1])
+
+def test_changing_label_string(qtbot:QtBot)->None:
+    """Tests changing the label string"""
+    check_combobox = QCheckComboBox()
+    check_combobox.setLabelText("Please select items")
+    assert(check_combobox.labelText()=="Please select items")
+
+def test_selected_items_label_type(qtbot:QtBot)->None:
+    """Tests selected item label"""
+    check_combobox = QCheckComboBox()
+    check_combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+    assert(check_combobox.labelType() == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+
+    check_combobox.addItem("Item 1")
+    check_combobox.addItems(["Item 2", "Item 3"])
+    assert(check_combobox.labelText()=="Item 1, Item 2, Item 3")
+
+def test_paint_event(qtbot:QtBot)->None:
+    """Simple test for paint event; execute without error"""
+    check_combobox = QCheckComboBox()
+    check_combobox.setLabelText("A new label")
+    check_combobox.paintEvent(QEvent(QEvent.Paint))
+
+def test_hidepopup(qtbot:QtBot)->None:
+    check_combobox = QCheckComboBox()
+    check_combobox._changed = True
+    check_combobox.hidePopup()
+    assert(check_combobox._changed==False)
+    check_combobox.hidePopup()
+
+def test_handle_item_checked(qtbot:QtBot)->None:
+    """Tests the check combobox interactions"""
+    check_combobox = QCheckComboBox()
+    check_combobox.addItems(["Item 1", "Item 2"], [True, False])
+    check_combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+    model = check_combobox.model()
+
+    model_index = model.index(0,0)
+    check_combobox._handleItemPressed(model_index)
+    assert(check_combobox.itemChecked(0) == False)
+
+    model_index = model.index(1,0)
+    check_combobox._handleItemPressed(model_index)
+    assert(check_combobox.itemChecked(1) == True)

--- a/tests/test_check_combobox.py
+++ b/tests/test_check_combobox.py
@@ -1,9 +1,10 @@
-from tabnanny import check
-from superqt import QCheckComboBox
 from pytestqt.qtbot import QtBot
 from qtpy.QtCore import QEvent
 
-def test_add_item(qtbot:QtBot)->None:
+from superqt import QCheckComboBox
+
+
+def test_add_item(qtbot: QtBot) -> None:
     """Tests the addition of item"""
 
     check_combobox = QCheckComboBox()
@@ -11,98 +12,114 @@ def test_add_item(qtbot:QtBot)->None:
     check_combobox.addItem("Item 1", userData=1, checked=False)
     check_combobox.addItem("Item 2", userData="2", checked=True)
 
-    assert(check_combobox.itemData(0)==1)
-    assert(check_combobox.itemData(1)=="2")
-    assert(check_combobox.itemText(0)=="Item 1")
-    assert(check_combobox.itemText(1)=="Item 2")
+    assert check_combobox.itemData(0) == 1
+    assert check_combobox.itemData(1) == "2"
+    assert check_combobox.itemText(0) == "Item 1"
+    assert check_combobox.itemText(1) == "Item 2"
 
-def test_add_items(qtbot:QtBot)->None:
+
+def test_add_items(qtbot: QtBot) -> None:
     """Tests the addition of items"""
 
     check_combobox1 = QCheckComboBox()
     check_combobox1.addItems(["Item 1", "Item 2", "Item 3"])
-    assert(check_combobox1.itemText(0)=="Item 1")
-    assert(check_combobox1.itemText(1)=="Item 2")
-    assert(check_combobox1.itemText(2)=="Item 3")
+    assert check_combobox1.itemText(0) == "Item 1"
+    assert check_combobox1.itemText(1) == "Item 2"
+    assert check_combobox1.itemText(2) == "Item 3"
 
     check_combobox2 = QCheckComboBox()
     check_combobox2.addItems(["Item 1", "Item 2"], checked=False)
-    assert(check_combobox2.itemChecked(0)==False)
-    assert(check_combobox2.itemChecked(1)==False)
+    assert check_combobox2.itemChecked(0) is False
+    assert check_combobox2.itemChecked(1) is False
 
     check_combobox3 = QCheckComboBox()
     check_combobox3.addItems(["Item 1", "Item 2"], checked=True)
-    assert(check_combobox3.itemChecked(0)==True)
-    assert(check_combobox3.itemChecked(1)==True)
+    assert check_combobox3.itemChecked(0) is True
+    assert check_combobox3.itemChecked(1) is True
 
     check_combobox4 = QCheckComboBox()
     check_combobox4.addItems(["Item 1", "Item 2"], checked=[True, False])
-    assert(check_combobox4.itemChecked(0)==True)
-    assert(check_combobox4.itemChecked(1)==False)
+    assert check_combobox4.itemChecked(0) is True
+    assert check_combobox4.itemChecked(1) is False
 
 
-def test_set_all_items_checked(qtbot:QtBot)->None:
+def test_set_all_items_checked(qtbot: QtBot) -> None:
     """Tests setting all items checked status"""
     check_combobox = QCheckComboBox()
     check_combobox.addItems(["Item 1", "Item 2", "Item 3"], checked=[True, False, True])
-    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
-    assert(checked_status == [True, False, True])
+    checked_status = [
+        check_combobox.itemChecked(i) for i in range(check_combobox.count())
+    ]
+    assert checked_status == [True, False, True]
 
     check_combobox.setAllItemChecked(False)
-    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
-    assert(checked_status == [False, False, False])
+    checked_status = [
+        check_combobox.itemChecked(i) for i in range(check_combobox.count())
+    ]
+    assert checked_status == [False, False, False]
 
     check_combobox.setAllItemChecked(True)
-    checked_status = [check_combobox.itemChecked(i) for i in range(check_combobox.count())]
-    assert(checked_status == [True, True, True])
+    checked_status = [
+        check_combobox.itemChecked(i) for i in range(check_combobox.count())
+    ]
+    assert checked_status == [True, True, True]
 
-def test_indices_retrival(qtbot:QtBot)->None:
+
+def test_indices_retrival(qtbot: QtBot) -> None:
     """Tests retrival of the indices checked and unchecked"""
     check_combobox = QCheckComboBox()
     check_combobox.addItems(["Item 1", "Item 2", "Item 3"], checked=[True, False, True])
-    assert(check_combobox.checkedIndices()==[0,2])
-    assert(check_combobox.uncheckedIndices()==[1])
+    assert check_combobox.checkedIndices() == [0, 2]
+    assert check_combobox.uncheckedIndices() == [1]
 
-def test_changing_label_string(qtbot:QtBot)->None:
+
+def test_changing_label_string(qtbot: QtBot) -> None:
     """Tests changing the label string"""
     check_combobox = QCheckComboBox()
     check_combobox.setLabelText("Please select items")
-    assert(check_combobox.labelText()=="Please select items")
+    assert check_combobox.labelText() == "Please select items"
 
-def test_selected_items_label_type(qtbot:QtBot)->None:
+
+def test_selected_items_label_type(qtbot: QtBot) -> None:
     """Tests selected item label"""
     check_combobox = QCheckComboBox()
     check_combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
-    assert(check_combobox.labelType() == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
+    assert (
+        check_combobox.labelType()
+        == QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS
+    )
 
     check_combobox.addItem("Item 1")
     check_combobox.addItems(["Item 2", "Item 3"])
-    assert(check_combobox.labelText()=="Item 1, Item 2, Item 3")
+    assert check_combobox.labelText() == "Item 1, Item 2, Item 3"
 
-def test_paint_event(qtbot:QtBot)->None:
+
+def test_paint_event(qtbot: QtBot) -> None:
     """Simple test for paint event; execute without error"""
     check_combobox = QCheckComboBox()
     check_combobox.setLabelText("A new label")
     check_combobox.paintEvent(QEvent(QEvent.Paint))
 
-def test_hidepopup(qtbot:QtBot)->None:
+
+def test_hidepopup(qtbot: QtBot) -> None:
     check_combobox = QCheckComboBox()
     check_combobox._changed = True
     check_combobox.hidePopup()
-    assert(check_combobox._changed==False)
+    assert check_combobox._changed is False
     check_combobox.hidePopup()
 
-def test_handle_item_checked(qtbot:QtBot)->None:
+
+def test_handle_item_checked(qtbot: QtBot) -> None:
     """Tests the check combobox interactions"""
     check_combobox = QCheckComboBox()
     check_combobox.addItems(["Item 1", "Item 2"], [True, False])
     check_combobox.setLabelType(QCheckComboBox.QCheckComboBoxLabelType.SELECTED_ITEMS)
     model = check_combobox.model()
 
-    model_index = model.index(0,0)
+    model_index = model.index(0, 0)
     check_combobox._handleItemPressed(model_index)
-    assert(check_combobox.itemChecked(0) == False)
+    assert check_combobox.itemChecked(0) is False
 
-    model_index = model.index(1,0)
+    model_index = model.index(1, 0)
     check_combobox._handleItemPressed(model_index)
-    assert(check_combobox.itemChecked(1) == True)
+    assert check_combobox.itemChecked(1) is True


### PR DESCRIPTION
This implements the QCheckComboBox that is discussed in #89.  A few notes:

- `addItems` and `addItem` included `checked` parameters to quickly initializes the items while adding. We can remove that if you feel that it doesn't follow the "zen" of qt.
- Quite a few convenience functions are added to the widget to retrieve and control the items, e.g., get the indices of all checked items, set checked states of all items.
- The label of the combobox has two modes: 1) static set by the user or a list of all selected items. The example included showcases this feature.
- Still getting to know qtbot for actual interface testing. I was planning on using it for `_handleItemPressed` test but I failed. For now, it is being tested like any other function.

As always, I am open to suggestions and modifications. In terms of functionality, this is what I needed for my use case but others might have other ideas.

p.s. I see that the list of comboboxes in superqt is growing (enum, search) which is great.
