### PR TITLE
fix: catch qpixmap deprecation

### DIFF
--- a/src/superqt/fonticon/_qfont_icon.py
+++ b/src/superqt/fonticon/_qfont_icon.py
@@ -243,7 +243,9 @@ class _QFontIconEngine(QIconEngine):
     def pixmap(self, size: QSize, mode: QIcon.Mode, state: QIcon.State) -> QPixmap:
         # first look in cache
         pmckey = self._pmcKey(size, mode, state)
-        pm = QPixmapCache.find(pmckey) if pmckey else None
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "QPixmapCache.find")
+            pm = QPixmapCache.find(pmckey) if pmckey else None
         if pm:
             return pm
         pixmap = QPixmap(size)


### PR DESCRIPTION
Catches and ignores a (buggy) deprecation warning about QPixmapCache.find.  

This was seemingly temporarily deprecated: https://doc.qt.io/qt-5/qpixmapcache-obsolete.html ... but it's back and undeprecated in Qt6.
see also https://stackoverflow.com/questions/57484593/how-to-fix-pyside2-qpixmapcache-find-deprecationwarning