### PR TITLE
Fix float value error in pyqt configuration

### DIFF
--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -128,7 +128,7 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
         super().__init__(parent)
 
         self._slider = self._slider_class()
-        self._label = SliderLabel(self._slider, connect=self._slider.setValue)
+        self._label = SliderLabel(self._slider, connect=self._setValue)
         self._edge_label_mode: EdgeLabelMode = EdgeLabelMode.LabelIsValue
 
         self._rename_signals()
@@ -141,6 +141,13 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
         self._slider.valueChanged.connect(self.valueChanged.emit)
 
         self.setOrientation(orientation)
+
+    def _setValue(self, value: float):
+        """
+        Convert the value from float to int before
+        setting the slider value
+        """
+        self._slider.setValue(int(value))
 
     def _rename_signals(self):
         # for subclasses

--- a/tests/test_sliders/test_labeled_slider.py
+++ b/tests/test_sliders/test_labeled_slider.py
@@ -1,4 +1,4 @@
-from superqt import QLabeledRangeSlider
+from superqt import QLabeledRangeSlider, QLabeledSlider
 
 
 def test_labeled_slider_api(qtbot):
@@ -9,3 +9,10 @@ def test_labeled_slider_api(qtbot):
     slider.setBarVisible()
     slider.setBarMovesAllHandles()
     slider.setBarIsRigid()
+
+
+def test_slider_connect_works(qtbot):
+    slider = QLabeledSlider()
+    qtbot.addWidget(slider)
+
+    slider._label.editingFinished.emit()


### PR DESCRIPTION
In the pyqt5 configuration, the `QLabeledSlider` throws an error due to `QDoubleSpinBox` returning a float rather than an int.

Here I propose to add a proxy `_setValue` function which does the conversion :)
