### PR TITLE
Bump qtpy to at least 1.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 install_requires =
     packaging
     pygments>=2.4.0
-    qtpy>=1.1.0
+    qtpy>=1.10.0
     typing-extensions
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
To import `SignalInstance` from `qtpy.QtCore` the minimum version of qtpy is `1.10` 