### PR TITLE
Simple workaround for pyside 6

### DIFF
--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -12,7 +12,10 @@ NONE_STRING = "----"
 
 def _get_name(enum_value: Enum):
     """Create human readable name if user does not provide own implementation of __str__"""
-    if enum_value.__str__.__module__ != "enum":
+    if (
+        enum_value.__str__.__module__ != "enum"
+        and not enum_value.__str__.__module__.startswith("shibokensupport")
+    ):
         # check if function was overloaded
         name = str(enum_value)
     else:


### PR DESCRIPTION
I found that recent version of pyside6 overwrite __str__ method of `Enum` class, so checking if str method belongs either to `enum` or `shibokensupport` modules solves this problem. 

But I'm not sure if it is a goo d idea as it may impact on some related enums. 

Maybe the best option will be to wait on the next PySide6 release? Maybe they will solve it?

fixes: #118