### PR TITLE
fix: fix quantity set value and add test

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install for screenshots
         if: matrix.screenshot
-        run: pip install . ${{ matrix.backend }}
+        run: pip install -e .[${{ matrix.backend }}]
 
       - name: Screenshots (Linux)
         if: runner.os == 'Linux' && matrix.screenshot

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ pyqt6 =
 pyside2 =
     pyside2
 pyside6 =
-    pyside6
+    pyside6<6.4.0
 quantity =
     pint
 testing =

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -69,7 +69,7 @@ class QQuantity(QWidget):
 
     def __init__(
         self,
-        value: Union[str, Quantity, Number],
+        value: Union[str, Quantity, Number] = 0,
         units: Union[UnitsContainer, str, Quantity] = None,
         ureg: Optional[UnitRegistry] = None,
         parent: Optional[QWidget] = None,
@@ -166,7 +166,12 @@ class QQuantity(QWidget):
         units: Union[UnitsContainer, str, Quantity] = None,
     ) -> None:
         """Set the current value (will cast to a pint Quantity)."""
-        new_val = self._ureg.Quantity(value, units=units)
+        if isinstance(value, Quantity):
+            if units is not None:
+                raise ValueError("Cannot specify units if value is a Quantity")
+            new_val = self._ureg.Quantity(value.magnitude, units=value.units)
+        else:
+            new_val = self._ureg.Quantity(value, units=units)
 
         mag_change = new_val.magnitude != self._value.magnitude
         units_change = new_val.units != self._value.units

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1,3 +1,5 @@
+from pint import Quantity
+
 from superqt import QQuantity
 
 
@@ -29,3 +31,11 @@ def test_qquantity(qtbot):
     assert w.isDimensionless()
     assert w.unitsComboBox().currentText() == "-----"
     assert w.magnitude() == 1
+
+
+def test_change_qquantity_value(qtbot):
+    w = QQuantity()
+    qtbot.addWidget(w)
+    assert w.value() == Quantity(0)
+    w.setValue(Quantity("1 meter"))
+    assert w.value() == Quantity("1 meter")


### PR DESCRIPTION
fixes a bug in `QQuantity` when using `setValue()` with an instance of `pint.Quantity`.  Also makes the initial value optional (defaulting to a dimensionless magnitude of zero)